### PR TITLE
DEV: adds robots.txt file

### DIFF
--- a/static/robots.txt
+++ b/static/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Allow: /

--- a/static/robots.txt
+++ b/static/robots.txt
@@ -1,15 +1,44 @@
 User-Agent: GPTBot
+Disallow: /
+
 User-Agent: ClaudeBot
+Disallow: /
+
 User-Agent: Claude-Web
+Disallow: /
+
 User-Agent: Applebot-Extended
+Disallow: /
+
 User-Agent: Facebookbot
+Disallow: /
+
 User-Agent: Meta-ExternalAgent
+Disallow: /
+
 User-Agent: diffbot
+Disallow: /
+
 User-Agent: PerplexityBot
+Disallow: /
+
 User-Agent: Omgili
+Disallow: /
+
 User-Agent: Omgilibot
+Disallow: /
+
 User-Agent: ImagesiftBot
+Disallow: /
+
 User-Agent: Bytespider
+Disallow: /
+
 User-Agent: Amazonbot
+Disallow: /
+
 User-Agent: Youbot
 Disallow: /
+
+User-Agent: *
+Allow: /

--- a/static/robots.txt
+++ b/static/robots.txt
@@ -1,2 +1,15 @@
-User-agent: *
-Allow: /
+User-Agent: GPTBot
+User-Agent: ClaudeBot
+User-Agent: Claude-Web
+User-Agent: Applebot-Extended
+User-Agent: Facebookbot
+User-Agent: Meta-ExternalAgent
+User-Agent: diffbot
+User-Agent: PerplexityBot
+User-Agent: Omgili
+User-Agent: Omgilibot
+User-Agent: ImagesiftBot
+User-Agent: Bytespider
+User-Agent: Amazonbot
+User-Agent: Youbot
+Disallow: /


### PR DESCRIPTION
This PR adds a robots.txt file to serve at `/robots.txt`

We don't have one right now, so we show a 404 for that path. This PR fixes that. 

The content is basic for now

```
User-Agent: GPTBot
Disallow: /

User-Agent: ClaudeBot
Disallow: /

User-Agent: Claude-Web
Disallow: /

User-Agent: Applebot-Extended
Disallow: /

User-Agent: Facebookbot
Disallow: /

User-Agent: Meta-ExternalAgent
Disallow: /

User-Agent: diffbot
Disallow: /

User-Agent: PerplexityBot
Disallow: /

User-Agent: Omgili
Disallow: /

User-Agent: Omgilibot
Disallow: /

User-Agent: ImagesiftBot
Disallow: /

User-Agent: Bytespider
Disallow: /

User-Agent: Amazonbot
Disallow: /

User-Agent: Youbot
Disallow: /

User-Agent: *
Allow: /
```

It disallows the bots listed on 

https://robotstxt.com/ai

While allowing other bots to crawl the site.

Note that respecting robots.txt is not something we control. It's up to the bot. 

That said, having one is better than a 404 page at least as far as Googlebot is concerned.
