### PR TITLE
UX: changes "why weird section to further reading"

### DIFF
--- a/src/routes/components/WhyWeird.svelte
+++ b/src/routes/components/WhyWeird.svelte
@@ -44,10 +44,10 @@
 
     <div class="content">
       <h3>{sectionHeading}</h3>
-      <h4>{sectionSubheading}</h4>
+      <span class="section-subheading">{sectionSubheading}</span>
 
       <div class="link-list">
-        <h5>{ProductLinksHeading}</h5>
+        <span class="list-heading">{ProductLinksHeading}</span>
         <ul>
           {#each ProductLinks as { text, url }}
             <li>
@@ -64,7 +64,7 @@
       </div>
 
       <div class="link-list">
-        <h5>{protocolLinksHeading}</h5>
+        <span class="list-heading">{protocolLinksHeading}</span>
         <ul>
           {#each protocolLinks as { text, url }}
             <li>
@@ -128,14 +128,16 @@
     margin-bottom: 0.25em;
   }
 
-  h4 {
-    font-size: 1.25em;
+  .section-subheading {
+    font-size: 1.5em;
     margin-bottom: 3em;
+    display: block;
   }
 
-  h5 {
+  .list-heading {
     font-size: 1.5em;
     margin-bottom: 1.25em;
+    display: block;
   }
 
   ul {

--- a/src/routes/components/WhyWeird.svelte
+++ b/src/routes/components/WhyWeird.svelte
@@ -1,7 +1,9 @@
 <script>
-  const title = "Further Reading";
+  const sectionHeading = "Further Reading";
+  const sectionSubheading = "for the nerds";
 
-  const links = [
+  const ProductLinksHeading = "Product";
+  const ProductLinks = [
     {
       text: "Magic website creator",
       url: "https://blog.erlend.sh/weird-web-pages",
@@ -11,8 +13,20 @@
       url: "https://blog.erlend.sh/weird-netizens",
     },
     {
-      text: "Further reading (for the nerds)",
+      text: "Weird Happenings",
       url: "https://blog.commune.sh/weird-happenings/",
+    },
+  ];
+
+  const protocolLinksHeading = "Protocols";
+  const protocolLinks = [
+    {
+      text: "How to Federate?",
+      url: "https://zicklag.katharos.group/blog/how-to-federate/",
+    },
+    {
+      text: "A Web of Data",
+      url: "https://zicklag.katharos.group/blog/a-web-of-data/",
     },
   ];
 </script>
@@ -29,20 +43,42 @@
     </div>
 
     <div class="content">
-      <h3>{title}</h3>
-      <ul>
-        {#each links as { text, url }}
-          <li>
-            <a href={url}>
-              <span class="link-text">{text}</span>
-              <span
-                class="link-arrow
+      <h3>{sectionHeading}</h3>
+      <h4>{sectionSubheading}</h4>
+
+      <div class="link-list">
+        <h5>{ProductLinksHeading}</h5>
+        <ul>
+          {#each ProductLinks as { text, url }}
+            <li>
+              <a href={url}>
+                <span class="link-text">{text}</span>
+                <span
+                  class="link-arrow
                 ">➜</span
-              >
-            </a>
-          </li>
-        {/each}
-      </ul>
+                >
+              </a>
+            </li>
+          {/each}
+        </ul>
+      </div>
+
+      <div class="link-list">
+        <h5>{protocolLinksHeading}</h5>
+        <ul>
+          {#each protocolLinks as { text, url }}
+            <li>
+              <a href={url}>
+                <span class="link-text">{text}</span>
+                <span
+                  class="link-arrow
+                ">➜</span
+                >
+              </a>
+            </li>
+          {/each}
+        </ul>
+      </div>
     </div>
   </div>
 </section>
@@ -83,20 +119,27 @@
     }
   }
 
-  h3 {
-    font-family: "uncutsans";
-    font-size: 3.5em;
-    margin: 0 0 0.75em 0;
+  .link-list {
+    margin-bottom: 4em;
   }
 
-  p {
-    font-size: 2em;
-    margin: 0 0 1.5em;
+  h3 {
+    font-size: 3.5em;
+    margin-bottom: 0.25em;
+  }
+
+  h4 {
+    font-size: 1.25em;
+    margin-bottom: 3em;
+  }
+
+  h5 {
+    font-size: 1.5em;
+    margin-bottom: 1.25em;
   }
 
   ul {
     width: 350px;
-    margin-top: 4.5em;
   }
 
   li {

--- a/src/routes/components/WhyWeird.svelte
+++ b/src/routes/components/WhyWeird.svelte
@@ -1,19 +1,17 @@
 <script>
-  const title = "Why Weird?";
-  const firstParagraph = `Weird wants to be "the Google-login button of the people's web", powered by people's websites instead of totalitarian mega-platforms.`;
-  const secondParagraph = `By making (or connecting) your website with Weird you will soon be able to access and interact with the small, open and indie web just as easily as the regular web works today. Same conveniences, without the dark patterns, spying and data theft. For more on why this matters, fellow internet nerds are welcome to read on:`;
+  const title = "Further Reading";
 
   const links = [
     {
-      text: "weird web pages",
+      text: "Magic website creator",
       url: "https://blog.erlend.sh/weird-web-pages",
     },
     {
-      text: "weird netizens",
+      text: "Web Passports",
       url: "https://blog.erlend.sh/weird-netizens",
     },
     {
-      text: "weird happenings",
+      text: "Further reading (for the nerds)",
       url: "https://blog.commune.sh/weird-happenings/",
     },
   ];
@@ -32,12 +30,6 @@
 
     <div class="content">
       <h3>{title}</h3>
-      <p>
-        {firstParagraph}
-      </p>
-      <p>
-        {secondParagraph}
-      </p>
       <ul>
         {#each links as { text, url }}
           <li>
@@ -64,10 +56,10 @@
 
   .container {
     display: grid;
-    grid-template-columns: 25% 1fr;
+    grid-template-columns: 35% 1fr;
     justify-content: end;
-    padding-top: 8em;
-    gap: 8em;
+    padding-top: 12em;
+    gap: 6em;
   }
 
   .image {
@@ -94,7 +86,7 @@
   h3 {
     font-family: "uncutsans";
     font-size: 3.5em;
-    margin: 2em 0 0.75em 0;
+    margin: 0 0 0.75em 0;
   }
 
   p {
@@ -103,7 +95,7 @@
   }
 
   ul {
-    width: 275px;
+    width: 350px;
     margin-top: 4.5em;
   }
 


### PR DESCRIPTION
This PR modifies the "why Weird" section on the homepage to simplify it and focus on linking to more detailed articles.

Before:
![home weird one_](https://github.com/user-attachments/assets/1403d4ab-809b-4ba5-bc22-22d05f2a6167)


After:
![localhost_5173_ (1)](https://github.com/user-attachments/assets/85548549-71a7-4d67-9b53-4d7f81cc11c2)


