### PR TITLE
FEATURE: adds markdown-based subpages

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
 engine-strict=true
+package-lock=false

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@sveltejs/vite-plugin-svelte": "^4.0.0-next.6",
     "svelte": "^5.0.0-next.241",
     "typescript": "^5.0.0",
-    "vite": "^5.0.3"
+    "vite": "^5.0.3",
+    "marked": "^14.1.0"
   }
 }

--- a/src/app.html
+++ b/src/app.html
@@ -119,7 +119,10 @@
       }
 
       .container {
-        padding: 3.5em 8.5vw;
+        padding: 3.5em 6.5vw;
+        width: 100%;
+        max-width: 1700px;
+        margin: 0 auto;
       }
 
       @media (max-width: 768px) {

--- a/src/lib/Markdown.svelte
+++ b/src/lib/Markdown.svelte
@@ -1,4 +1,3 @@
-<!-- lib/Markdown.svelte -->
 <script>
   import { marked } from "marked";
 

--- a/src/lib/Markdown.svelte
+++ b/src/lib/Markdown.svelte
@@ -1,0 +1,8 @@
+<!-- lib/Markdown.svelte -->
+<script>
+  import { marked } from "marked";
+
+  export let rawMarkdown = "";
+</script>
+
+{@html marked(rawMarkdown)}

--- a/src/lib/Markdown.svelte
+++ b/src/lib/Markdown.svelte
@@ -1,7 +1,36 @@
 <script>
   import { marked } from "marked";
-
-  export let rawMarkdown = "";
+  export let rawMarkdown;
 </script>
 
-{@html marked(rawMarkdown)}
+<div class="markdown-content">
+  {@html marked(rawMarkdown)}
+</div>
+
+<style>
+  .markdown-content {
+    /* these are styles for cooked markdown
+       without :global they get purged
+    */
+
+    :global(p) {
+      margin-bottom: 1.5em;
+      font-size: 2em;
+    }
+
+    :global(a) {
+      color: currentColor;
+    }
+
+    :global(ul) {
+      font-size: 2em;
+      margin-bottom: 1.5em;
+      padding-left: 1em;
+      list-style-type: disc;
+
+      :global(li) {
+        margin-bottom: 0.5em;
+      }
+    }
+  }
+</style>

--- a/src/lib/SiteHeader.svelte
+++ b/src/lib/SiteHeader.svelte
@@ -30,6 +30,10 @@
 </div>
 
 <style>
+  .header {
+    padding: 0.75em;
+  }
+
   .container {
     display: grid;
     grid-template-columns: 1fr auto;

--- a/src/routes/(app)/+layout.svelte
+++ b/src/routes/(app)/+layout.svelte
@@ -1,0 +1,27 @@
+<script>
+  import SiteHeader from "$lib/SiteHeader.svelte";
+</script>
+
+<SiteHeader />
+<div class="stars"></div>
+<main>
+  <slot />
+</main>
+
+<style>
+  :global(body) {
+    background: linear-gradient(180deg, #250941 25%, #de7287);
+    min-height: 100vh;
+  }
+
+  .stars {
+    background: url("/stars.avif");
+    height: 40vh;
+    width: 100%;
+    background-position: center;
+    position: absolute;
+    left: 0;
+    top: 0;
+    z-index: -1;
+  }
+</style>

--- a/src/routes/(app)/+layout.svelte
+++ b/src/routes/(app)/+layout.svelte
@@ -13,7 +13,6 @@
     background: linear-gradient(180deg, #250941 25%, #de7287);
     min-height: 100vh;
   }
-
   .stars {
     background: url("/stars.avif");
     height: 40vh;

--- a/src/routes/(app)/components/Content.svelte
+++ b/src/routes/(app)/components/Content.svelte
@@ -1,0 +1,92 @@
+<script>
+  import Markdown from "$lib/Markdown.svelte";
+
+  export let heading;
+  export let description;
+  export let rawMarkdown;
+</script>
+
+<div class="container">
+  <div class="title">
+    <h1>{heading}</h1>
+    <p>{description}</p>
+  </div>
+  <div class="content">
+    <Markdown {rawMarkdown} />
+  </div>
+</div>
+
+<style>
+  .container {
+    color: white;
+    padding-bottom: 15em;
+
+    .title {
+      display: grid;
+      grid-template-columns: 0.4fr auto;
+      padding: 2em;
+      place-items: center;
+
+      gap: 2em;
+
+      h1 {
+        font-family: "Rubik Mono One", monospace;
+        font-size: 3.25em;
+        margin: 0;
+        width: 400px;
+        line-height: 1.5;
+        letter-spacing: 0.5px;
+        user-select: none;
+      }
+
+      p {
+        font-size: 2em;
+        margin: 0;
+        line-height: 1.5;
+      }
+
+      @media (max-width: 1200px) {
+        grid-template-columns: 1fr;
+        h1 {
+          font-size: 2.5em;
+          width: 100%;
+        }
+
+        p {
+          font-size: 1.5em;
+        }
+      }
+    }
+
+    .content {
+      margin: 8em 0 12em 0;
+      background: #683481;
+      padding: 5em 8em;
+      border-radius: var(--border-radius);
+      border: 2px solid black;
+
+      /* these are styles for cooked markdown
+         without :global they get purged
+      */
+      :global(p) {
+        margin-bottom: 1.5em;
+        font-size: 2em;
+      }
+
+      :global(a) {
+        color: white;
+      }
+
+      :global(ul) {
+        font-size: 2em;
+        margin-bottom: 1.5em;
+        padding-left: 1em;
+        list-style-type: disc;
+
+        :global(li) {
+          margin-bottom: 0.5em;
+        }
+      }
+    }
+  }
+</style>

--- a/src/routes/(app)/components/Content.svelte
+++ b/src/routes/(app)/components/Content.svelte
@@ -1,6 +1,5 @@
 <script>
   import Markdown from "$lib/Markdown.svelte";
-
   export let heading;
   export let description;
   export let rawMarkdown;
@@ -20,15 +19,12 @@
   .container {
     color: white;
     padding-bottom: 15em;
-
     .title {
       display: grid;
       grid-template-columns: 0.4fr auto;
       padding: 2em;
       place-items: center;
-
       gap: 2em;
-
       h1 {
         font-family: "Rubik Mono One", monospace;
         font-size: 3.25em;
@@ -38,55 +34,28 @@
         letter-spacing: 0.5px;
         user-select: none;
       }
-
       p {
         font-size: 2em;
         margin: 0;
         line-height: 1.5;
       }
-
       @media (max-width: 1200px) {
         grid-template-columns: 1fr;
         h1 {
           font-size: 2.5em;
           width: 100%;
         }
-
         p {
           font-size: 1.5em;
         }
       }
     }
-
     .content {
       margin: 8em 0 12em 0;
       background: #683481;
       padding: 5em 8em;
       border-radius: var(--border-radius);
       border: 2px solid black;
-
-      /* these are styles for cooked markdown
-         without :global they get purged
-      */
-      :global(p) {
-        margin-bottom: 1.5em;
-        font-size: 2em;
-      }
-
-      :global(a) {
-        color: white;
-      }
-
-      :global(ul) {
-        font-size: 2em;
-        margin-bottom: 1.5em;
-        padding-left: 1em;
-        list-style-type: disc;
-
-        :global(li) {
-          margin-bottom: 0.5em;
-        }
-      }
     }
   }
 </style>

--- a/src/routes/(app)/magic-website-creator/+page.svelte
+++ b/src/routes/(app)/magic-website-creator/+page.svelte
@@ -1,0 +1,10 @@
+<script>
+  import Content from "../components/Content.svelte";
+  import rawMarkdown from "./magic-website-creator.md?raw";
+
+  const heading = "Magic website creator";
+  const description =
+    "To fully inhabit the World Wide Web (interwebs for fun, or just the web for short), you need to create your digital self within it.";
+</script>
+
+<Content {heading} {rawMarkdown} {description} />

--- a/src/routes/(app)/magic-website-creator/+page.svelte
+++ b/src/routes/(app)/magic-website-creator/+page.svelte
@@ -1,7 +1,6 @@
 <script>
   import Content from "../components/Content.svelte";
   import rawMarkdown from "./magic-website-creator.md?raw";
-
   const heading = "Magic website creator";
   const description =
     "To fully inhabit the World Wide Web (interwebs for fun, or just the web for short), you need to create your digital self within it.";

--- a/src/routes/(app)/magic-website-creator/magic-website-creator.md
+++ b/src/routes/(app)/magic-website-creator/magic-website-creator.md
@@ -1,0 +1,25 @@
+The way to do that is a personal website [why? Links1,2,3]
+
+For a lot of us, the “simple” prospect of filling in that web page with content presents an insurmountable writer’s block.
+
+Thankfully, Wikipedia’s Irene Clark offers plenty of coping strategies, one of which we’re going all-in on:
+
+Making lists!!! [three exclamation points make a vertical list icon; maybe we can play with that graphic]
+
+Since we’re on the interwebs, the best things to list are web-links.
+
+..like your existing web identities
+
+- mastodon 🦣
+- github :octocat:
+- matrix 💬
+
+(in which case we can import your personal contents from there and simply use that as your personal web page for now)
+
+..or it could just be your three favorite movies
+
+- Toy Story 🤠
+- Twilight 🧛
+- Titanic 🚢
+
+Whatever you’ve listed, you’ve done it! You told us something about yourself. Now, not only are you taking up a bit of space on the web, as you should. You’ve also got your very own web-passport 🪪

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -4,7 +4,7 @@
   import Description from "./components/Description.svelte";
   import Features from "./components/Features.svelte";
   import Marquee from "./components/Marquee.svelte";
-  import WhyWeird from "./components/WhyWeird.svelte";
+  import FurtherReading from "./components/FurtherReading.svelte";
   import SiteFooter from "$lib/SiteFooter.svelte";
 </script>
 
@@ -13,7 +13,7 @@
 <Description />
 <Features />
 <Marquee />
-<WhyWeird />
+<FurtherReading />
 <SiteFooter />
 
 <style>

--- a/src/routes/components/Features.svelte
+++ b/src/routes/components/Features.svelte
@@ -1,19 +1,9 @@
 <script>
+  import WebPasspostsCard from "./feature-cards/web-passports.svelte";
+  import MagicWebsiteCreatorCard from "./feature-cards/magic-website-creator.svelte";
+
   const preludeText = "just like milk and honey...";
   const heading = "Weird is a combination of two things that go together";
-
-  const cards = [
-    {
-      icon: "➢",
-      title: "Magic website creation",
-      body: "The simplest possible way to create your own personal space on the web.",
-    },
-    {
-      icon: "➣",
-      title: "Self-sovereign internet passport",
-      body: "Independent 'social sign-in' for the alt-web.",
-    },
-  ];
 </script>
 
 <section class="features">
@@ -31,15 +21,8 @@
       <h2>{heading}</h2>
     </div>
     <div class="cards">
-      {#each cards as { icon, title, body }}
-        <div class="card">
-          <div>
-            <span class="icon">{icon}</span>
-            <h3>{title}</h3>
-            <p>{body}</p>
-          </div>
-        </div>
-      {/each}
+      <MagicWebsiteCreatorCard />
+      <WebPasspostsCard />
     </div>
   </div>
 </section>
@@ -85,27 +68,6 @@
 
     @media (max-width: 900px) {
       grid-template-columns: 1fr;
-    }
-  }
-
-  .card {
-    background: #9bafe1;
-    padding: 3em 4em;
-    border-radius: var(--border-radius);
-    box-shadow: 0px 3px 0 5px black;
-    position: relative;
-
-    .icon {
-      font-size: 5em;
-    }
-
-    h3 {
-      font-size: 2.5em;
-      margin: 1em 0;
-    }
-
-    p {
-      font-size: 1.75em;
     }
   }
 </style>

--- a/src/routes/components/FurtherReading.svelte
+++ b/src/routes/components/FurtherReading.svelte
@@ -35,7 +35,7 @@
   ];
 </script>
 
-<section class="why-weird">
+<section class="further-reading">
   <div class="container">
     <div class="image">
       <img
@@ -88,7 +88,7 @@
 </section>
 
 <style>
-  .why-weird {
+  .further-reading {
     background: linear-gradient(180deg, #240940 40%, #8e4569);
     color: white;
     padding-bottom: 8em;

--- a/src/routes/components/WhyWeird.svelte
+++ b/src/routes/components/WhyWeird.svelte
@@ -18,8 +18,12 @@
     },
   ];
 
-  const protocolLinksHeading = "Protocols";
+  const protocolLinksHeading = "Protocol";
   const protocolLinks = [
+    {
+      text: "The Leaf Protocol",
+      url: "https://zicklag.katharos.group/blog/introducing-leaf-protocol/",
+    },
     {
       text: "How to Federate?",
       url: "https://zicklag.katharos.group/blog/how-to-federate/",
@@ -88,14 +92,15 @@
     background: linear-gradient(180deg, #240940 40%, #8e4569);
     color: white;
     padding-bottom: 8em;
+    display: grid;
   }
 
   .container {
-    display: grid;
-    grid-template-columns: 35% 1fr;
-    justify-content: end;
+    display: inline-grid;
+    grid-template-columns: 1fr 1fr;
     padding-top: 12em;
-    gap: 6em;
+    gap: 7em;
+    margin: 0 auto;
 
     @media (max-width: 800px) {
       grid-template-columns: 1fr;

--- a/src/routes/components/feature-cards/card.svelte
+++ b/src/routes/components/feature-cards/card.svelte
@@ -1,0 +1,32 @@
+<div class="card">
+  <div>
+    <span class="icon">
+      <slot name="icon" />
+    </span>
+    <h3>
+      <slot name="title" />
+    </h3>
+    <div class="body">
+      <slot name="body" />
+    </div>
+  </div>
+</div>
+
+<style>
+  .card {
+    background: #9bafe1;
+    padding: 3em 4em;
+    border-radius: var(--border-radius);
+    box-shadow: 0px 3px 0 5px black;
+    position: relative;
+
+    .icon {
+      font-size: 5em;
+    }
+
+    h3 {
+      font-size: 2.5em;
+      margin: 1em 0;
+    }
+  }
+</style>

--- a/src/routes/components/feature-cards/magic-website-creator.md
+++ b/src/routes/components/feature-cards/magic-website-creator.md
@@ -1,0 +1,7 @@
+To fully inhabit the World Wide Web you need to create your digital self within it.
+
+For a lot of us, the “simple” prospect of filling in that web page with content presents an insurmountable [writer’s block](https://en.wikipedia.org/wiki/Writer%27s_block).
+
+That’s why we start with _link lists_ as a primitive building block. Make a _list_ of 1, 3 or however many `links` that say something, anything, about you.
+
+Whatever you’ve listed, you’ve done it! You told us something about your self, and with that you are taking up a bit of space on the web, as you should.

--- a/src/routes/components/feature-cards/magic-website-creator.svelte
+++ b/src/routes/components/feature-cards/magic-website-creator.svelte
@@ -1,0 +1,12 @@
+<script>
+  import Card from "./card.svelte";
+  import rawMarkdown from "./magic-website-creator.md?raw";
+  import Markdown from "$lib/Markdown.svelte";
+</script>
+
+<Card>
+  <span slot="icon">➢</span>
+  <span slot="title">Magic Website Creator</span>
+
+  <Markdown {rawMarkdown} slot="body" />
+</Card>

--- a/src/routes/components/feature-cards/web-passports.md
+++ b/src/routes/components/feature-cards/web-passports.md
@@ -1,0 +1,3 @@
+Weird is the “Google-login” button of the alt-web. A [web of the people](https://blog.erlend.sh/web-of-the-people), powered by people's websites instead of those pesky totalitarian mega-platforms.
+
+By making - or merely connecting - your website with Weird you will soon be able to access and interact with the small, open and indie web just as easily as the regular web works today. Same conveniences, without the dark patterns, spying and data theft.

--- a/src/routes/components/feature-cards/web-passports.svelte
+++ b/src/routes/components/feature-cards/web-passports.svelte
@@ -1,0 +1,12 @@
+<script>
+  import Card from "./card.svelte";
+  import rawMarkdown from "./web-passports.md?raw";
+  import Markdown from "$lib/Markdown.svelte";
+</script>
+
+<Card>
+  <span slot="icon">➣</span>
+  <span slot="title">Web Passports</span>
+
+  <Markdown {rawMarkdown} slot="body" />
+</Card>


### PR DESCRIPTION
This PR does the following

1. Adds a new layout for subpages that can be used to expand on the product.
2. Adds a new reusable Markdown component that "cooks" the markdown so that we can serve it as static content
3. Adds a new reusable Content component for those pages. This ensures that the styles and layout are reused everywhere for now
4. Makes a few general style changes on the site. The changes are minor padding, margin, max-width CSS changes so they shouldn't have any major impacts/
5. Adds the first subpage (Magic website creator) at `/magic-website-creator` that looks like this

![localhost_5173_magic-website-creator (1)](https://github.com/user-attachments/assets/93f6f262-1bc5-43bd-a964-7edda2b7a551)

The "Magic website creator" page still needs work in terms of style but in this PR it's used as an example of adding a subpage.

After this PR, adding new subpages is simple. 

1. create a new folder in `/routes/(app)/<SLUG>`
2. create Markdown file in that folder like `my-page.md`
3. create a `+page.svelte` that looks like this

```
<script>
  import Content from "../components/Content.svelte";
  import rawMarkdown from "./<my-page.md>?raw";

  const heading = "<MY_HEADING>";
  const description ="<MY_DESCRIPTION>";
</script>

<Content {heading} {rawMarkdown} {description} />
```

This will create a new page at the slug you specify in the folder name and you can just use standard markdown in the `.md` file.
