### PR TITLE
DEV: updates "feature" cards on the landing page

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@sveltejs/vite-plugin-svelte": "^4.0.0-next.6",
     "svelte": "^5.0.0-next.241",
     "typescript": "^5.0.0",
-    "vite": "^5.0.3"
+    "vite": "^5.0.3",
+    "marked": "^14.1.0"
   }
 }

--- a/src/lib/Markdown.svelte
+++ b/src/lib/Markdown.svelte
@@ -1,0 +1,36 @@
+<script>
+  import { marked } from "marked";
+  export let rawMarkdown;
+</script>
+
+<div class="markdown-content">
+  {@html marked(rawMarkdown)}
+</div>
+
+<style>
+  .markdown-content {
+    /* these are styles for cooked markdown
+       without :global they get purged
+    */
+
+    :global(p) {
+      margin-bottom: 1.5em;
+      font-size: 2em;
+    }
+
+    :global(a) {
+      color: currentColor;
+    }
+
+    :global(ul) {
+      font-size: 2em;
+      margin-bottom: 1.5em;
+      padding-left: 1em;
+      list-style-type: disc;
+
+      :global(li) {
+        margin-bottom: 0.5em;
+      }
+    }
+  }
+</style>

--- a/src/routes/components/Features.svelte
+++ b/src/routes/components/Features.svelte
@@ -1,19 +1,9 @@
 <script>
+  import WebPasspostsCard from "./feature-cards/web-passports.svelte";
+  import MagicWebsiteCreatorCard from "./feature-cards/magic-website-creator.svelte";
+
   const preludeText = "just like milk and honey...";
   const heading = "Weird is a combination of two things that go together";
-
-  const cards = [
-    {
-      icon: "➢",
-      title: "Magic website creation",
-      body: "The simplest possible way to create your own personal space on the web.",
-    },
-    {
-      icon: "➣",
-      title: "Self-sovereign internet passport",
-      body: "Independent 'social sign-in' for the alt-web.",
-    },
-  ];
 </script>
 
 <section class="features">
@@ -31,15 +21,8 @@
       <h2>{heading}</h2>
     </div>
     <div class="cards">
-      {#each cards as { icon, title, body }}
-        <div class="card">
-          <div>
-            <span class="icon">{icon}</span>
-            <h3>{title}</h3>
-            <p>{body}</p>
-          </div>
-        </div>
-      {/each}
+      <MagicWebsiteCreatorCard />
+      <WebPasspostsCard />
     </div>
   </div>
 </section>
@@ -85,27 +68,6 @@
 
     @media (max-width: 900px) {
       grid-template-columns: 1fr;
-    }
-  }
-
-  .card {
-    background: #9bafe1;
-    padding: 3em 4em;
-    border-radius: var(--border-radius);
-    box-shadow: 0px 3px 0 5px black;
-    position: relative;
-
-    .icon {
-      font-size: 5em;
-    }
-
-    h3 {
-      font-size: 2.5em;
-      margin: 1em 0;
-    }
-
-    p {
-      font-size: 1.75em;
     }
   }
 </style>

--- a/src/routes/components/feature-cards/card.svelte
+++ b/src/routes/components/feature-cards/card.svelte
@@ -1,0 +1,32 @@
+<div class="card">
+  <div>
+    <span class="icon">
+      <slot name="icon" />
+    </span>
+    <h3>
+      <slot name="title" />
+    </h3>
+    <div class="body">
+      <slot name="body" />
+    </div>
+  </div>
+</div>
+
+<style>
+  .card {
+    background: #9bafe1;
+    padding: 3em 4em;
+    border-radius: var(--border-radius);
+    box-shadow: 0px 3px 0 5px black;
+    position: relative;
+
+    .icon {
+      font-size: 5em;
+    }
+
+    h3 {
+      font-size: 2.5em;
+      margin: 1em 0;
+    }
+  }
+</style>

--- a/src/routes/components/feature-cards/magic-website-creator.md
+++ b/src/routes/components/feature-cards/magic-website-creator.md
@@ -1,6 +1,6 @@
-To fully inhabit the World Wide Web you need to create your digital self within it. The way to do that is with a personal website [why? Links1,2,3]
+To fully inhabit the World Wide Web you need to create your digital self within it.
 
-For a lot of us, the “simple” prospect of filling in that web page with content presents an insurmountable [writer’s block](https://en.wikipedia.org/wiki/Writer%27s_block). (Can we make this look like a special Wikipedia-specific link?)
+For a lot of us, the “simple” prospect of filling in that web page with content presents an insurmountable [writer’s block](https://en.wikipedia.org/wiki/Writer%27s_block).
 
 That’s why we start with _link lists_ as a primitive building block. Make a _list_ of 1, 3 or however many `links` that say something, anything, about you.
 

--- a/src/routes/components/feature-cards/magic-website-creator.md
+++ b/src/routes/components/feature-cards/magic-website-creator.md
@@ -1,0 +1,7 @@
+To fully inhabit the World Wide Web you need to create your digital self within it. The way to do that is with a personal website [why? Links1,2,3]
+
+For a lot of us, the “simple” prospect of filling in that web page with content presents an insurmountable [writer’s block](https://en.wikipedia.org/wiki/Writer%27s_block). (Can we make this look like a special Wikipedia-specific link?)
+
+That’s why we start with _link lists_ as a primitive building block. Make a _list_ of 1, 3 or however many `links` that say something, anything, about you.
+
+Whatever you’ve listed, you’ve done it! You told us something about your self, and with that you are taking up a bit of space on the web, as you should.

--- a/src/routes/components/feature-cards/magic-website-creator.svelte
+++ b/src/routes/components/feature-cards/magic-website-creator.svelte
@@ -1,0 +1,12 @@
+<script>
+  import Card from "./card.svelte";
+  import rawMarkdown from "./magic-website-creator.md?raw";
+  import Markdown from "$lib/Markdown.svelte";
+</script>
+
+<Card>
+  <span slot="icon">➢</span>
+  <span slot="title">Magic Website Creator</span>
+
+  <Markdown {rawMarkdown} slot="body" />
+</Card>

--- a/src/routes/components/feature-cards/web-passports.md
+++ b/src/routes/components/feature-cards/web-passports.md
@@ -1,0 +1,3 @@
+Weird is the “Google-login” button of the alt-web. A [web of the people](https://blog.erlend.sh/web-of-the-people), powered by people's websites instead of those pesky totalitarian mega-platforms.
+
+By making - or merely connecting - your website with Weird you will soon be able to access and interact with the small, open and indie web just as easily as the regular web works today. Same conveniences, without the dark patterns, spying and data theft.

--- a/src/routes/components/feature-cards/web-passports.svelte
+++ b/src/routes/components/feature-cards/web-passports.svelte
@@ -1,0 +1,12 @@
+<script>
+  import Card from "./card.svelte";
+  import rawMarkdown from "./web-passports.md?raw";
+  import Markdown from "$lib/Markdown.svelte";
+</script>
+
+<Card>
+  <span slot="icon">➣</span>
+  <span slot="title">Web Passposts</span>
+
+  <Markdown {rawMarkdown} slot="body" />
+</Card>

--- a/src/routes/components/feature-cards/web-passports.svelte
+++ b/src/routes/components/feature-cards/web-passports.svelte
@@ -6,7 +6,7 @@
 
 <Card>
   <span slot="icon">➣</span>
-  <span slot="title">Web Passposts</span>
+  <span slot="title">Web Passports</span>
 
   <Markdown {rawMarkdown} slot="body" />
 </Card>


### PR DESCRIPTION
This PR does two things:

1. Adds a new reusable `<Markdown>` component that takes raw markdown and cooks it
2. Updates the "features" section on the landing page with new copy and makes it use the new `<Markdown>` component.

desktop:

Before:

![before](https://github.com/user-attachments/assets/d521b44b-b2a9-408f-8fb9-6b0690c1cfa6)

after:

![after](https://github.com/user-attachments/assets/4c1204c1-abc4-4bee-b8fb-15011eb864c6)


mobile:

before:

![home weird one_ (5)](https://github.com/user-attachments/assets/0a0bb8ec-dbe1-4803-a8ee-a686b1090fb8)

After:

![landing_4](https://github.com/user-attachments/assets/a554d171-6a87-47bc-a18f-3bc367fab423)

After this PR, editing the cards should be simple. The "content" is located at 

`/src/routes/components/feature-cards`

You can edit the markdown content in the `.md` file here for the body or the `.svelte` file for the icon and title.
