### PR TITLE
UX: updates the further reading section styles and links

### DIFF
--- a/src/routes/components/WhyWeird.svelte
+++ b/src/routes/components/WhyWeird.svelte
@@ -92,14 +92,15 @@
     background: linear-gradient(180deg, #240940 40%, #8e4569);
     color: white;
     padding-bottom: 8em;
+    display: grid;
   }
 
   .container {
-    display: grid;
-    grid-template-columns: 35% 1fr;
-    justify-content: end;
+    display: inline-grid;
+    grid-template-columns: 1fr 1fr;
     padding-top: 12em;
-    gap: 6em;
+    gap: 7em;
+    margin: 0 auto;
 
     @media (max-width: 800px) {
       grid-template-columns: 1fr;

--- a/src/routes/components/WhyWeird.svelte
+++ b/src/routes/components/WhyWeird.svelte
@@ -18,7 +18,7 @@
     },
   ];
 
-  const protocolLinksHeading = "Protocols";
+  const protocolLinksHeading = "Protocol";
   const protocolLinks = [
     {
       text: "How to Federate?",

--- a/src/routes/components/WhyWeird.svelte
+++ b/src/routes/components/WhyWeird.svelte
@@ -21,6 +21,10 @@
   const protocolLinksHeading = "Protocol";
   const protocolLinks = [
     {
+      text: "The Leaf Protocol",
+      url: "https://zicklag.katharos.group/blog/introducing-leaf-protocol/",
+    },
+    {
       text: "How to Federate?",
       url: "https://zicklag.katharos.group/blog/how-to-federate/",
     },


### PR DESCRIPTION
This PR does the following

1. Fixes a typo in the heading for the protocol section heading 
2. Adds a new link to the Leaf protocol blog post
3. Centers the entire section since we moved from paragraphs to a list of links

Before:

![before-desktop](https://github.com/user-attachments/assets/d0e6e8d7-29fb-47f2-bd45-c35cd700ce11)


After:

![after-desktop](https://github.com/user-attachments/assets/396ef1c3-a9cb-49e2-bfe9-9de891c1b60d)
