### PR TITLE
UX: ensure marquee has relative positioning and correct CSS overflow

### DIFF
--- a/src/routes/components/Marquee.svelte
+++ b/src/routes/components/Marquee.svelte
@@ -17,6 +17,8 @@
     display: grid;
     place-items: center;
     font-weight: 700;
+    position: relative;
+    overflow: hidden;
 
     .content {
       color: #240940;


### PR DESCRIPTION
The animation in the marquee currently causes the page to horizontally scroll like so

![home weird one_ (8)](https://github.com/user-attachments/assets/662aff5a-367c-4546-b4b6-a246d776ac62)

This PR fixes that so that it never goes out of the bounds of the viewport like so

![home weird one_ (10)](https://github.com/user-attachments/assets/058b9e41-79f5-4a89-bcd8-5269a55f7663)

The animation will keep moving but after this PR, it won't cause horizontal scrollbars.