### PR TITLE
DEV: add Github stars widget

### DIFF
--- a/src/lib/GithubBadge.svelte
+++ b/src/lib/GithubBadge.svelte
@@ -1,0 +1,10 @@
+<div class="badge">
+  <a
+    class="github-button"
+    href="https://github.com/muni-town/weird-website"
+    data-color-scheme="no-preference: light; light: light; dark: light;"
+    data-show-count="true"
+    aria-label="Star muni-town/weird-website on GitHub">Star</a
+  >
+  <script async defer src="https://buttons.github.io/buttons.js"></script>
+</div>

--- a/src/lib/SiteHeader.svelte
+++ b/src/lib/SiteHeader.svelte
@@ -5,7 +5,6 @@
 
   const menuLinks = [
     { text: "Members", url: "https://weird.one/members" },
-    { text: "Profile", url: "https://weird.one/auth/v1/account" },
     { text: "Register", url: "https://weird.one/auth/v1/users/register" },
   ];
 </script>

--- a/src/lib/SiteHeader.svelte
+++ b/src/lib/SiteHeader.svelte
@@ -1,4 +1,6 @@
 <script>
+  import GithubBadge from "./GithubBadge.svelte";
+
   const siteName = "Weird";
 
   const menuLinks = [
@@ -24,6 +26,10 @@
             </a>
           </li>
         {/each}
+
+        <li>
+          <GithubBadge />
+        </li>
       </ul>
     </div>
   </div>


### PR DESCRIPTION
This PR adds a small Github star count to the header and removes the profile link.

Before:

<img width="427" alt="image" src="https://github.com/user-attachments/assets/3f58a2f8-9eab-47f9-abf5-4acae432ab5c">

After:

<img width="427" alt="image" src="https://github.com/user-attachments/assets/0fe1911c-8b56-4712-b7e1-81d858faed5b">