### PR TITLE
FIX: update Github badge repository 

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -38,6 +38,13 @@
       crossorigin="anonymous"
     />
 
+    <!-- github badge script -->
+    <link
+      rel="preload"
+      href="https://buttons.github.io/buttons.js"
+      as="script"
+    />
+
     <!--preload images-->
     <link rel="preload" href="/stars.avif" as="image" type="image/avif" />
     <link rel="preload" href="/hero.svg" as="image" type="image/svg+xml" />

--- a/src/lib/GithubBadge.svelte
+++ b/src/lib/GithubBadge.svelte
@@ -1,10 +1,10 @@
 <div class="badge">
   <a
     class="github-button"
-    href="https://github.com/muni-town/weird-website"
+    href="https://github.com/muni-town/weird"
     data-color-scheme="no-preference: light; light: light; dark: light;"
     data-show-count="true"
-    aria-label="Star muni-town/weird-website on GitHub">Star</a
+    aria-label="Star muni-town/weird on GitHub">Star</a
   >
   <script async defer src="https://buttons.github.io/buttons.js"></script>
 </div>


### PR DESCRIPTION
1. Right now, we're linking to the website repository. We want it to actually link to Weird's repository.
2. Adds a preload link for the script needed for the badge. 

(We should probably just skip the badge "widget" altogether and create the link with a build-time `fetch` to get the stars + icon.)