### PR TITLE
PERF: load youtube video iframe after a click

### DIFF
--- a/src/lib/YouTubeEmbed.svelte
+++ b/src/lib/YouTubeEmbed.svelte
@@ -1,0 +1,85 @@
+<script>
+  export let videoId = "";
+  export let title = "";
+  export let playerFeatures = ["autoplay"];
+
+  const thumbnailUrl = `https://img.youtube.com/vi/${videoId}/maxresdefault.jpg`;
+  const iframeSrc = `https://www.youtube.com/embed/${videoId}?autoplay=1`;
+
+  let showIframe = false;
+
+  const onThumbnailClick = () => {
+    showIframe = true;
+  };
+</script>
+
+<div class="youtube-embed">
+  {#if showIframe}
+    <iframe
+      src={iframeSrc}
+      allowfullscreen
+      {title}
+      allow={playerFeatures.join(" ")}
+    ></iframe>
+  {:else}
+    <div
+      class="thumbnail"
+      role="button"
+      tabindex="0"
+      on:click={onThumbnailClick}
+      on:keydown={(event) => {
+        if (event.key === "Enter") onThumbnailClick();
+      }}
+    >
+      <img src={thumbnailUrl} alt={title} loading="lazy" />
+      <div class="play-button">
+        <svg viewBox="0 0 24 24" fill="white">
+          <path d="M8 5v14l11-7z" />
+        </svg>
+      </div>
+    </div>
+  {/if}
+</div>
+
+<style>
+  .youtube-embed {
+    --apect-ratio: 16 / 9;
+
+    .thumbnail {
+      position: relative;
+      cursor: pointer;
+
+      .play-button {
+        position: absolute;
+        top: 50%;
+        left: 50%;
+        transform: translate(-50%, -50%);
+        background-color: rgba(0, 0, 0, 0.7);
+        border-radius: 50%;
+        width: 60px;
+        height: 60px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+
+        svg {
+          width: 30px;
+          height: 30px;
+        }
+      }
+    }
+
+    img,
+    iframe {
+      width: 1200px;
+      max-width: 100%;
+      max-height: 85vh;
+      aspect-ratio: var(--apect-ratio);
+      border-radius: var(--border-radius);
+      box-shadow: 0 5px 20px #00000080;
+      margin-top: 5em;
+      border: 0;
+      object-fit: cover;
+    }
+  }
+</style>

--- a/src/routes/components/further-reading/Video.svelte
+++ b/src/routes/components/further-reading/Video.svelte
@@ -1,34 +1,21 @@
 <script>
   import Markdown from "$lib/Markdown.svelte";
+  import YouTubeEmbed from "$lib/YouTubeEmbed.svelte";
+
   import rawMarkdown from "./video.md?raw";
 
-  const videoTitle = "Agentic Product Development - Erlend Sogge Heggen";
-  const videoSrc = "https://www.youtube-nocookie.com/embed/YgYKKCmcE04";
+  const videoId = "YgYKKCmcE04";
+  const title = "Agentic Product Development - Erlend Sogge Heggen";
 </script>
 
-<div class="container video-container">
+<div class="container">
   <Markdown {rawMarkdown} />
-
-  <iframe src={videoSrc} title={videoTitle} loading="lazy" allowfullscreen
-  ></iframe>
+  <YouTubeEmbed {videoId} {title} />
 </div>
 
 <style>
-  .video-container {
-    --apect-ratio: 16 / 9;
-
+  .container {
     padding-top: 12em;
     padding-bottom: 6em;
-
-    iframe {
-      width: 1200px;
-      max-width: 100%;
-      max-height: 85vh;
-      aspect-ratio: var(--apect-ratio);
-      border-radius: var(--border-radius);
-      box-shadow: 0px 5px 20px rgba(0, 0, 0, 0.5);
-      margin-top: 5em;
-      border: 0;
-    }
   }
 </style>


### PR DESCRIPTION
Right now we have a youtube video on the landing page loaded via an iframe. 

This is fine, but youtube video iframes load a lot of scripts. 

![before](https://github.com/user-attachments/assets/1a281a54-8c96-4d26-b0ed-71e078c30359)

What this PR does is that it creates a new reusable component that you can pass the `videoId` and `title` to and it would then

1. get the thumbnail for the video (which is also lazy-loaded)
2. show it with a "play" button on top
3. when it's clicked, it will swap the thumbnail with the iframe

This means that we defer a ton of javascript (which comes from the youtube iframe) until the user shows clear intent.

This change cuts down landing page resource size from 4.4mb to 655kb (before compression)

![after](https://github.com/user-attachments/assets/5be05d76-efce-4c63-8a10-e081c5dc751f)

There are 0 visual changes beyond that the video now shows up as a thumbnail until you click on it.
