### PR TITLE
UX: update Github star badge styles

### DIFF
--- a/src/lib/GithubBadge.svelte
+++ b/src/lib/GithubBadge.svelte
@@ -21,62 +21,36 @@
   class="github-star-button"
   aria-label="Star on GitHub"
 >
-  <span class="text"><GithubIcon /> Star</span>
+  <GithubIcon />
   <span class="count">{count}</span>
 </a>
 
 <style>
   /* these match the GitHub button styles */
   .github-star-button {
-    color: #25292e;
-    background: #ebf0f4;
-    border: 1px solid #d1d9e0;
-    border-radius: 3px;
     text-decoration: none;
-    padding: 0.25em;
-    display: grid;
     grid-auto-flow: column;
-    gap: 0.5em;
+    gap: 1em;
     place-items: center;
-    font-size: 0.9em;
     display: grid;
     font-family: system-ui;
     min-height: 20px;
     font-weight: 600;
 
-    .text {
-      color: #25292e;
-      display: grid;
-      gap: 0.25em;
-      grid-auto-flow: column;
-      place-items: center;
-      padding: 0 0.25em;
-
-      &:hover {
-        background-position: 0 -0.5em;
-        background: linear-gradient(180deg, #eff2f5, #e5eaee 90%);
-        border-color: #d1d9e0;
-      }
-    }
-
     .count {
-      padding: 0 0.25em;
+      color: white;
+      min-width: 2ch;
 
-      border-left: 1px solid #d1d9e0;
-
-      &:hover {
-        color: #0969da;
+      &:hover,
+      &:focus,
+      &:active {
+        color: white;
       }
     }
 
     :global(svg) {
-      fill: #25292e;
-      height: 1.25em;
-      width: 1.25em;
+      fill: white;
+      height: 2em;
     }
-  }
-
-  .github-star-button span {
-    font-size: 1.25em;
   }
 </style>

--- a/src/lib/SiteHeader.svelte
+++ b/src/lib/SiteHeader.svelte
@@ -56,7 +56,16 @@
     ul {
       display: grid;
       grid-auto-flow: column;
-      gap: 4em;
+      gap: 2em;
+
+      li {
+        cursor: pointer;
+        border-radius: var(--border-radius);
+        padding: 0.5em;
+        &:hover {
+          background: rgba(255, 255, 255, 0.5);
+        }
+      }
 
       a {
         color: white;


### PR DESCRIPTION
Continuing from #21 

Right now we have this

![before](https://github.com/user-attachments/assets/55a67092-345e-4a3b-9acd-9e9eef38f948)

We want the Github badge to have a slightly more muted style.

This PR does that and adds a hover state to header links


https://github.com/user-attachments/assets/43935cee-fb58-4767-aee7-dca951bd333f

